### PR TITLE
#18 Add isIndependentUpdate (ignore timeScale)

### DIFF
--- a/Editor/DOTweenTimelineEditor.cs
+++ b/Editor/DOTweenTimelineEditor.cs
@@ -45,6 +45,8 @@ namespace Dott.Editor
             {
                 Repaint();
             }
+			
+            Timeline.isIndependentUpdate = EditorGUILayout.Toggle( "Ignore TimeScale", Timeline.isIndependentUpdate );
         }
 
         private void OnEnable()

--- a/Runtime/DOTweenTimeline.cs
+++ b/Runtime/DOTweenTimeline.cs
@@ -8,6 +8,9 @@ namespace Dott
     public class DOTweenTimeline : MonoBehaviour
     {
         [CanBeNull] public Sequence Sequence { get; private set; }
+		
+        //  If TRUE the sequence will ignore Unity's Time.timeScale
+        public bool isIndependentUpdate;
 
         // Do not override the onKill callback because it is used internally to reset the Sequence
         public Sequence Play()
@@ -53,6 +56,7 @@ namespace Dott
                         break;
                 }
             }
+            Sequence.SetUpdate( isIndependentUpdate );
         }
 
         private void OnDestroy()


### PR DESCRIPTION
Add isIndependentUpdate (ignore timeScale), akin to the option on dotween animations to ignore Unity's timeScale.

#18 